### PR TITLE
Upgrade to unity 5.5.1p3

### DIFF
--- a/Examples/DemoScene/Scripts/DemoSceneMain.cs
+++ b/Examples/DemoScene/Scripts/DemoSceneMain.cs
@@ -302,7 +302,8 @@ namespace GAudio.Examples
 				lerpVal 	+= Time.deltaTime * factor;
 				appliedColor = Color.Lerp( fromColor, targetColor, lerpVal );
 				
-				fftLine.Line.SetColors( appliedColor, fftLine.endColor );
+				fftLine.Line.startColor = appliedColor;
+				fftLine.Line.endColor = fftLine.endColor;
 				
 				yield return null;
 			}

--- a/Examples/DemoScene/Scripts/Helpers/PatternLine.cs
+++ b/Examples/DemoScene/Scripts/Helpers/PatternLine.cs
@@ -77,7 +77,8 @@ namespace GAudio.Examples
 					_isFading = false;
 				}
 				
-				_line.SetColors( lineStartColor, lineEndColor );
+				_line.startColor = lineStartColor;
+				_line.endColor = lineEndColor;
 			}
 			
 			if( index == 7 )
@@ -98,7 +99,8 @@ namespace GAudio.Examples
 			{
 				lerpVal += Time.deltaTime * factor;
 				alpha = Mathf.Lerp( fromAlpha, 0f, lerpVal );
-				_line.SetColors( lineStartColor, new Color( lineEndColor.r, lineEndColor.g, lineEndColor.b, alpha ) );
+				_line.startColor = lineStartColor;
+				_line.endColor = new Color (lineEndColor.r, lineEndColor.g, lineEndColor.b, alpha);
 				yield return null;
 			}
 			

--- a/Examples/_Example_05_Looper/LarsenWarning.cs
+++ b/Examples/_Example_05_Looper/LarsenWarning.cs
@@ -19,7 +19,7 @@ namespace GAudio.Examples
 			yield return Application.RequestUserAuthorization( UserAuthorization.Microphone );
 			if (Application.HasUserAuthorization( UserAuthorization.Microphone ) ) 
 			{
-                SceneManager.LoadScene( 1 );
+				SceneManager.LoadScene( 1 );
 			} 
 			else
 			{

--- a/Scripts/AnalysisAndDrawing/DrawAudioModule.cs
+++ b/Scripts/AnalysisAndDrawing/DrawAudioModule.cs
@@ -61,8 +61,10 @@ namespace GAudio
 			_lineRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
 			_lineRenderer.receiveShadows = false;
 			SetVertexCount();
-			_lineRenderer.SetColors( startColor, endColor );
-			_lineRenderer.SetWidth( lineWidthStart, lineWidthEnd );
+			_lineRenderer.startColor = startColor;
+			_lineRenderer.endColor = endColor;
+			_lineRenderer.startWidth = lineWidthStart;
+			_lineRenderer.endWidth = lineWidthEnd;
 			_lineRenderer.material = lineMaterial;
 			_lineRenderer.useWorldSpace = false;
 			
@@ -75,7 +77,7 @@ namespace GAudio
 		// Overridable for custom behaviour.
 		protected virtual void SetVertexCount()
 		{
-			_lineRenderer.SetVertexCount( _data.Length );
+			_lineRenderer.numPositions = _data.Length;
 		}
 		
 		//This override is called when you can thread safely handle new data. Let's draw it.

--- a/Scripts/AnalysisAndDrawing/DrawFFTModule.cs
+++ b/Scripts/AnalysisAndDrawing/DrawFFTModule.cs
@@ -40,7 +40,7 @@ namespace GAudio
 		
 		protected override void SetVertexCount()
 		{
-			_lineRenderer.SetVertexCount( _vertexCount );
+			_lineRenderer.numPositions =  _vertexCount;
 		}
 		
 		protected override void HandleAudioDataUpdate()

--- a/Scripts/Mixing/_Classes/Panning/GATChannelGain.cs
+++ b/Scripts/Mixing/_Classes/Panning/GATChannelGain.cs
@@ -14,6 +14,8 @@ namespace GAudio
 		public int ChannelNumber{ get; protected set; }
 		
 		protected float _gain;
+
+		protected float _prevGain;
 		
 		public virtual float Gain
 		{
@@ -21,8 +23,9 @@ namespace GAudio
 			{
 				return _gain;
 			}
-			private set
+			set
 			{
+				_prevGain = _gain;
 				_gain = value;
 			}
 		}
@@ -43,21 +46,7 @@ namespace GAudio
 		public float InterpolationDelta{ get; private set; }
 		
 		bool  _needsUpdate;
-		
-		public override float Gain
-		{
-			get 
-			{
-				return _gain;
-			}
-			private set
-			{
-				_prevGain = _gain;
-				_gain = value;
-			}
-		}
-		
-		float _prevGain = 0f;
+
 		public float PrevGain{ get{ return _prevGain; } }
 		
 		float _nextGain;

--- a/Scripts/StaticAndSingletons/GATAudioInit.cs
+++ b/Scripts/StaticAndSingletons/GATAudioInit.cs
@@ -75,7 +75,7 @@ namespace GAudio
 				yield return Application.RequestUserAuthorization( UserAuthorization.Microphone );
 				if (Application.HasUserAuthorization( UserAuthorization.Microphone ) )
 				{
-				    SceneManager.LoadScene(levelToLoad);
+					SceneManager.LoadScene( levelToLoad );
 				} 
 				else 
 				{
@@ -84,7 +84,7 @@ namespace GAudio
 			}
 			else
 			{
-			    SceneManager.LoadScene(levelToLoad);
+				SceneManager.LoadScene( levelToLoad );
 			}
 		}
 		

--- a/Scripts/StaticAndSingletons/GATManager.cs
+++ b/Scripts/StaticAndSingletons/GATManager.cs
@@ -5,6 +5,9 @@
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEngine.SceneManagement;
+
+
 #if GAT_IOS
 using GAudio.iOS;
 #endif
@@ -153,6 +156,8 @@ namespace GAudio
 				EditorApplication.update += Update;
 			}
 			#endif
+
+			SceneManager.sceneLoaded += OnLevelFinishedLoading;
 		}
 		
 		void OnDisable()
@@ -163,6 +168,8 @@ namespace GAudio
 			//For main thread suspension detection
 			EditorApplication.update -= Update;
 			#endif
+
+			SceneManager.sceneLoaded -= OnLevelFinishedLoading;
 		}
 		
 		void Start()
@@ -258,7 +265,7 @@ namespace GAudio
 			//System.GC.Collect();
 		}
 		
-		void OnLevelWasLoaded()
+		void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
 		{
 			GATInfo.UniqueInstance.SetSyncDspTime( AudioSettings.dspTime );
 		}


### PR DESCRIPTION
Modified code so that it produces no compile-time warnings or errors in Unity 5.5.1p3, and all examples appear to work correctly.